### PR TITLE
Add tag.namedUnion for union/tag shorthand

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function createTag (displayName) {
     return fn.apply(null, tag.args)
   }
 
-  if (typeof displayName === 'string') {
+  if (displayName) {
+    assert(typeof displayName === 'string', 'displayName must be a string if provided')
     Tag.name = displayName
     Tag.displayName = displayName
   }
@@ -118,5 +119,24 @@ function unionIs (types, type) {
   return types.some(Type => Type.is(type))
 }
 
+function createNamedTagUnion (names) {
+  assert(Array.isArray(names), 'Names must be an array')
+  const len = names.length
+  const tags = []
+  for (let i = 0; i < len; i++) {
+    const name = names[i]
+    assert(typeof name === 'string', `Name at index ${i} must be a string, not ${name}`)
+    tags.push(createTag(name))
+  }
+  const union = createTagUnion(tags)
+  for (let i = 0; i < len; i++) {
+    const name = names[i]
+    assert(union[name] === undefined, `Property name "${name}" is reserved on the union.`)
+    union[names[i]] = tags[i]
+  }
+  return union
+}
+
 createTag.union = createTagUnion
+createTag.namedUnion = createNamedTagUnion
 module.exports = createTag

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,12 @@ test('createTag should return a tag type', t => {
   })
 })
 
+test('createTag should throw if provided displayName is not a string', t => {
+  t.throws(() => {
+    tag(4)
+  }, /must be a string/)
+})
+
 test('Tag.is should return whether a value is of type Tag', t => {
   const Foo = tag()
   const foo = Foo()
@@ -212,4 +218,31 @@ test('Union.match should throw if a tag is not a member of the union', t => {
       Stray, () => 3
     ])
   }, /not in this union/)
+})
+
+test('createNamedTagUnion should create a union with tags assign to it', t => {
+  const Msg = tag.namedUnion(['Foo', 'Bar'])
+  t.is(Msg.has(Msg.Foo(1)), true)
+  t.is(Msg.has(Msg.Bar(2)), true)
+
+  t.is(Msg.Foo.is(Msg.Foo(8)), true)
+  t.is(Msg.Bar.is(Msg.Bar(7)), true)
+})
+
+test('createNamedTagUnion should throw if names is not an array', t => {
+  t.throws(() => {
+    tag.namedUnion({hello: 'world'})
+  }, /must be an array/)
+})
+
+test('createNamedTagUnion should throw if any name is not a string', t => {
+  t.throws(() => {
+    tag.namedUnion(['Hello', 2, 'World'])
+  }, /must be a string/)
+})
+
+test('createNamedTagUnion should throw if any name conflicts with a previous property', t => {
+  t.throws(() => {
+    tag.namedUnion(['has'])
+  }, /reserved/)
 })


### PR DESCRIPTION
This is a little shorthand that I often hand-write in my projects. I'm not sure it belongs in core but I'm adding it to play around with. Since we are not doing a 1.x for awhile, I'm not too concerned.