### PR TITLE
Rewrite to use named unions only

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,54 +12,38 @@ npm install tagmeme
 ## Usage
 
 ```js
-import tag from 'tagmeme'
+import {union} from 'tagmeme'
 import assert from 'assert'
 
-const Increment = tag()
-const Decrement = tag()
+const Result = union(['Ok', 'Err'])
 
-const Action = tag.union([
-  Increment,
-  Decrement
-])
+const err = Result.Err(new Error('My error'))
 
-const incrementAction = Increment(10)
-assert(Increment.is(incrementAction))
-assert(!Decrement.is(incrementAction))
-
-Increment.unwrap(incrementAction, n => {
-  assert(n === 10)
+const message = Result.match(err, {
+  Ok: () => 'No error',
+  Err: error => error.message
 })
 
-assert(Action.has(incrementAction))
-
-assert(Action.match(incrementAction, [
-  Increment, n => n,
-  Decrement, n => -n
-]) === 10)
+assert(message === 'My error')
 ```
 
 ## Documentation
 
-- `tag([displayName])`: create a **Tag** with an optional name
-- `tag.union(tags)`: create a **Union** of an array of Tags
+#### `union(kinds: string[]): Union`
+Create a tagged union.
 
-#### Tag
-  - `Tag(...args)`: create a tag of type `Tag` with arguments
-  - `Tag.is(tag)`: check whether `tag` is of type `Tag`
-  - `Tag.unwrap(tag, fn)`: calls `fn` with the arguments passed to `tag`. Throws an error if `tag` is not of type `Tag`.
+#### `Union[kind](data: any): Tag`
+Create a tag of the union containing `data` which can be retrieved via `Union.match`.
 
-#### Union
-  - `Union.has(tag)`: check whether `tag` is of a Tag type within `Union`
-  - `Union.match(tag, [type1, handler1, type2, handler2, ..., catchAll])`: pattern match on `tag`.
-    Throws if:
-      - `tag` is not of any of the union types
-      - `tag` does not match any type and there is no `catchAll`
-      - any `typeN` is not a Tag
-      - any `handlerN` is not a function
-      - if it handles all cases and there is a useless `catchAll`
-      - if it does not handle all cases and there is no `catchAll`
-      - if there is a Tag handled more than once
+#### `Union.match(tag, handlers, catchAll)`
+Pattern match on `tag` with a hashmap of `handlers` where keys are kinds and values are functions, with an optional `catchAll` if no handler matches the value.
+Throws if:
+  - `tag` is not of any of the union types
+  - `tag` does not match any type and there is no `catchAll`
+  - any `handlers` key is not a kind in the union
+  - any `handlers` value is not a function
+  - it handles all cases and there is a useless `catchAll`
+  - it does not handle all cases and there is no `catchAll`
 
 ## Name
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,281 +1,107 @@
 import test from 'ava'
-import tag from '../index'
+import { union } from '../index'
 
-test('createTag should return a tag type', t => {
-  const Foo = tag()
-  const foo = Foo(0, 1, 2)
-
-  t.is(Foo.is(foo), true)
-  t.is(Foo.is(Foo), false)
-  t.is(Foo.is(0), false)
-
-  Foo.unwrap(foo, (x, y, z) => {
-    t.is(x, 0)
-    t.is(y, 1)
-    t.is(z, 2)
-  })
+test('union() should return an object with match method', t => {
+  const Msg = union([])
+  t.is(typeof Msg.match, 'function')
 })
 
-test('createTag should throw if provided displayName is not a string', t => {
-  t.throws(() => {
-    tag(4)
-  }, /must be a string/)
+test('union() should return an object with [kind] constructors', t => {
+  const Msg = union(['Foo'])
+  t.is(typeof Msg.Foo, 'function')
 })
 
-test('Tag.is should return whether a value is of type Tag', t => {
-  const Foo = tag()
-  const foo = Foo()
-  t.true(Foo.is(foo))
+test('union() should throw if kinds if not an array', t => {
+  t.throws(() => union(4), /must be an array/)
 })
 
-test('Tag.unwrap should throw if used on the wrong tag type', t => {
-  const Foo = tag()
-  const Bar = tag()
-  const bar = Bar(0)
-
-  t.throws(() => {
-    Foo.unwrap(bar, () => t.fail())
-  }, /Cannot unwrap/)
+test('union() should throw if kinds is not all strings', t => {
+  t.throws(() => union(['A', 4]), /must be a string/)
 })
 
-test('createTagUnion should return a union type', t => {
-  const Foo = tag()
-  const Bar = tag()
-  const Msg = tag.union([Foo, Bar])
-
-  const foo = Foo(12)
-  const bar = Bar(18)
-
-  t.is(Msg.has(foo), true)
-  t.is(Msg.has(bar), true)
-
-  const val = Msg.match(foo, [
-    Foo, n => {
-      t.is(n, 12)
-      return 8
-    },
-    Bar, () => t.fail()
-  ])
-
-  t.is(val, 8)
+test('union() should throw if there are duplicate kinds', t => {
+  t.throws(() => union(['A', 'A']), /must be unique/)
 })
 
-test('createTagUnion should throw if any type is not a Tag', t => {
-  const Foo = tag()
+test('union() should throw if there is a kind "match"', t => {
+  t.throws(() => union(['match']), /cannot be "match"/)
+})
+
+test('match() should return the handler return value', t => {
+  const Msg = union(['Foo'])
+  const val = Msg.Foo()
+
+  t.is(Msg.match(val, { Foo: () => 1 }), 1)
+})
+
+test('match() should call catchAll if a handler is not found', t => {
+  const Msg = union(['Foo', 'Bar'])
+  const val = Msg.Bar()
+
+  t.is(
+    Msg.match(
+      val,
+      {
+        Foo: () => 1
+      },
+      () => 2
+    ),
+    2
+  )
+})
+
+test('match() should throw if tag if not of the union', t => {
+  const A = union(['Foo'])
+  const B = union(['Bar'])
+
+  const tag = B.Bar()
 
   t.throws(() => {
-    tag.union([Foo, 4])
-  }, /Invalid Tag/)
-  t.throws(() => {
-    tag.union([4, Foo])
-  }, /Invalid Tag/)
-  t.throws(() => {
-    tag.union([1, Foo, 2])
-  }, /Invalid Tag/)
+    A.match(tag, {}, () => {})
+  }, /must be a tag of the union/)
 })
 
-test('createTagUnion should throw if there is a Tag duplicate', t => {
-  const Foo = tag()
-  t.throws(() => {
-    tag.union([Foo, Foo])
-  }, /Duplicate Tag/)
-})
-
-test('createTagUnion should throw if there is a duplicate Tag displayName', t => {
-  const Foo = tag('Foo')
-  const Bar = tag('Foo')
-  t.throws(() => {
-    tag.union([Foo, Bar])
-  }, /display name/)
-})
-
-test('Union should throw if called directly', t => {
-  t.throws(() => {
-    const Msg = tag.union([])
-    Msg()
-  }, /cannot be created/)
-})
-
-test('Union.has should return whether a value is a tag of one of the Union types', t => {
-  const Foo = tag()
-  const Bar = tag()
-  const Msg = tag.union([Foo])
-  const foo = Foo()
-  const bar = Bar()
-
-  t.false(Msg.has(4))
-  t.false(Msg.has(Foo))
-  t.true(Msg.has(foo))
-  t.false(Msg.has(Bar))
-  t.false(Msg.has(bar))
-})
-
-test('Union.match should allow a catch-all', t => {
-  const Foo = tag()
-  const Bar = tag()
-  const Msg = tag.union([Foo, Bar])
-
-  const foo = Foo(12)
-
-  Msg.match(foo, [
-    () => t.pass()
-  ])
-
-  Msg.match(foo, [
-    Bar, () => t.fail(),
-    () => t.pass()
-  ])
-})
-
-test('Union.match throws if catch-all is not a function', t => {
-  const Foo = tag()
-  const Msg = tag.union([Foo])
-  const foo = Foo()
+test('match() should throw if handler[kind] is not of the union', t => {
+  const Msg = union(['Foo'])
+  const val = Msg.Foo()
 
   t.throws(() => {
-    Msg.match(foo, [
-      Foo, () => {},
-      4
-    ])
-  }, /catch-all must be/)
+    Msg.match(val, { Bar: () => 1 })
+  }, /not a tag kind of the union/)
 })
 
-test('Union.match should throw if typeN is not a Tag', t => {
-  const Foo = tag()
-  const Msg = tag.union([Foo])
-  const foo = Foo()
+test('match() should throw if handler[kind] is not a function', t => {
+  const Msg = union(['Foo'])
+  const val = Msg.Foo()
 
   t.throws(() => {
-    Msg.match(foo, [
-      undefined, () => {},
-      4, () => {},
-      () => {}
-    ])
-  }, /type must be a Tag/)
-})
-
-test('Union.match should throw if handlerN is not a function', t => {
-  const Foo = tag()
-  const Msg = tag.union([Foo])
-  const foo = Foo()
-
-  t.throws(() => {
-    Msg.match(foo, [
-      Foo, 4,
-      () => {}
-    ])
+    Msg.match(val, { Foo: 4 })
   }, /must be a function/)
 })
 
-test('Union.match should throw if typeN is a duplicate Tag', t => {
-  const Foo = tag()
-  const Msg = tag.union([Foo])
-  const foo = Foo()
+test('match() should throw if a provided catchAll is not a function', t => {
+  const Msg = union(['Foo', 'Bar'])
+  const val = Msg.Foo()
 
   t.throws(() => {
-    Msg.match(foo, [
-      Foo, () => {},
-      Foo, () => {}
-    ])
-  }, /type can only be covered by one/)
+    Msg.match(val, { Foo: () => {} }, 4)
+  }, /must be a function/)
 })
 
-test('Union.match should throw if there are missing cases and no catch-all', t => {
-  const Foo = tag()
-  const Bar = tag()
-  const Msg = tag.union([Foo, Bar])
-
-  const foo = Foo(12)
+test('match() should throw if a catch-all is needed', t => {
+  const Msg = union(['Foo', 'Bar'])
+  const val = Msg.Foo()
 
   t.throws(() => {
-    Msg.match(foo, [
-      Foo, () => {}
-    ])
-  }, /Not all cases are covered/)
+    Msg.match(val, { Foo: () => {} })
+  }, /add a catch-all/)
 })
 
-test('Union.match should throw if there are missing cases and no catch-all', t => {
-  const Foo = tag('Foo')
-  const Bar = tag('Bar')
-  const Msg = tag.union([Foo, Bar])
-
-  const foo = Foo(12)
+test('match() should throw if a catch-all is not needed', t => {
+  const Msg = union(['Foo'])
+  const val = Msg.Foo()
 
   t.throws(() => {
-    Msg.match(foo, [
-      Foo, () => {}
-    ])
-  }, /Bar/)
-})
-
-test('Union.match should throw if all cases are handled and there is a catch-all', t => {
-  const Foo = tag()
-  const Msg = tag.union([Foo])
-
-  const foo = Foo()
-
-  t.throws(() => {
-    Msg.match(foo, [
-      Foo, () => {},
-      () => {}
-    ])
-  }, /All cases are covered/)
-})
-
-test('Union.match should throw if a tag is not a member of the union', t => {
-  const Foo = tag()
-  const Stray = tag('Stray')
-  const Msg = tag.union([Foo])
-
-  t.throws(() => {
-    Msg.match(Foo(1), [
-      Foo, () => 2,
-      Stray, () => 3
-    ])
-  }, /Stray/)
-
-  t.throws(() => {
-    Msg.match(Foo(1), [
-      Foo, () => 2,
-      Stray, () => 3
-    ])
-  }, /not in this union/)
-})
-
-test('createNamedTagUnion should create a union with tags assign to it', t => {
-  const Msg = tag.namedUnion(['Foo', 'Bar'])
-  t.is(Msg.has(Msg.Foo(1)), true)
-  t.is(Msg.has(Msg.Bar(2)), true)
-
-  t.is(Msg.Foo.is(Msg.Foo(8)), true)
-  t.is(Msg.Bar.is(Msg.Bar(7)), true)
-})
-
-test('createNamedTagUnion should throw if names is not an array', t => {
-  t.throws(() => {
-    tag.namedUnion({hello: 'world'})
-  }, /must be an array/)
-})
-
-test('createNamedTagUnion should throw if any name is not a string', t => {
-  t.throws(() => {
-    tag.namedUnion(['Hello', 2, 'World'])
-  }, /must be a string/)
-})
-
-test('createNamedTagUnion should throw if any name conflicts with a previous property', t => {
-  t.throws(() => {
-    tag.namedUnion(['has'])
-  }, /reserved/)
-})
-
-test('namedTagUnion.namedUnion should match with an object of handlers', t => {
-  const Msg = tag.namedUnion(['Foo', 'Bar'])
-
-  t.is(Msg.namedMatch(Msg.Foo(8), {
-    Foo: n => n,
-    Bar: n => 0
-  }), 8)
-
-  t.is(Msg.namedMatch(Msg.Foo(7), {}, () => 6), 6)
+    Msg.match(val, { Foo: () => {} }, () => {})
+  }, /remove unnecessary catch-all/)
 })


### PR DESCRIPTION
This is a rewrite of Tagmeme based on day-to-day use. In short, I only ever find myself using `namedUnion` and `namedMatch`. These methods seem best, providing the most guarantees (debugging name) and most natural syntax (using a hash-map for relating tag kinds to handlers).

The value of this rewrite is having a smaller surface area of only the right way to do things, and improving debugging: minimizing the stack trace depth for a `match` and adding a `_kind` property so we can more easily inspect the tag we are dealing with in the console. Performance of pattern matching is now also faster, O(1), using a hash-map instead of array.

We also remove the default export, now only a single named export `union` function is needed.
  