### PR TITLE
Add safeUnion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,31 @@ assert(isError)
 
 ## Documentation
 
-#### `union(types: string[], options: { prefix: string }): Union`
-Create a tagged union.
+This package includes:
 
-#### `Union[type](data: any): ({ type, data })`
+- [`union(types, options)`](#union)
+- [`Union[type](data)`](#uniontype)
+- [`Union.match(tag, handlers, catchAll)`](#unionmatch)
+- [`Union.matches(tag, variant)`](#unionmatches)
+- [`safeUnion(types, options)`](#safeunion)
+
+#### `union`
+> `union(types: Array<String>[, options: { prefix: String }]): Union`
+
+Create a tagged union. Throws if:
+  - `types` is not an array of unique strings
+  - any `types` are named "match" or "matches"
+
+See [`safeUnion`](#safeunion) if using arbitrary strings.
+
+#### `Union[type]`
+> `Union[type](data: any): ({ type, data })`
+
 Create a tag of the union containing `data` which can be retrieved via `Union.match`.
 
-#### `Union.match(tag, handlers, catchAll)`
+#### `Union.match`
+> `Union.match(tag, handlers[, catchAll: function])`
+
 Pattern match on `tag` with a hashmap of `handlers` where keys are kinds and values are functions, with an optional `catchAll` if no handler matches the value.
 Throws if:
   - `tag` is not of any of the union types
@@ -49,8 +67,16 @@ Throws if:
   - it handles all cases and there is a useless `catchAll`
   - it does not handle all cases and there is no `catchAll`
 
-#### `Union.matches(tag, Type): boolean`
+#### `Union.matches`
+> `Union.matches(tag, variant: Variant): boolean`
+
 Determine whether a given `tag` is of `Type`.
+
+#### `safeUnion`
+> `safeUnion(types: Array<String>[, options: { prefix: String }]): { methods, variants }`
+
+For library authors accepting arbitrary strings for type names, `safeUnion` is `union` but returns distinct collections of methods and type variants.
+This will not throw if a type is "match" or "matches".
 
 ## Name
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ const message = Result.match(err, {
 
 assert(message === 'My error')
 
+const handle = Result.matcher({
+  Ok: () => 'No error',
+  Err: error => error.message
+})
+
+assert(handle(err) === 'My error')
+
 const isError = Result.matches(err, Result.Err)
 
 assert(isError)
@@ -38,6 +45,7 @@ This package includes:
 - [`union(types, options)`](#union)
 - [`Union[type](data)`](#uniontype)
 - [`Union.match(tag, handlers, catchAll)`](#unionmatch)
+- [`Union.matcher(handlers, catchAll)`](#unionmatcher)
 - [`Union.matches(tag, variant)`](#unionmatches)
 - [`safeUnion(types, options)`](#safeunion)
 
@@ -46,7 +54,7 @@ This package includes:
 
 Create a tagged union. Throws if:
   - `types` is not an array of unique strings
-  - any `types` are named "match" or "matches"
+  - any `types` are named "match", "matcher", or "matches"
 
 See [`safeUnion`](#safeunion) if using arbitrary strings.
 
@@ -67,6 +75,15 @@ Throws if:
   - it handles all cases and there is a useless `catchAll`
   - it does not handle all cases and there is no `catchAll`
 
+#### `Union.matcher`
+> `Union.matcher(handlers[, catchAll: function])`
+
+Create a matching function which will take `tag` and `context` arguments.
+This reduces the boilerplate of a function that delegates to `Union.match` with static handlers.
+This is also a bit faster than `match` because the handler functions only need to be created once.
+
+Unlike with `match`, the second argument to handler will be `context` to avoid the need for a closure.
+
 #### `Union.matches`
 > `Union.matches(tag, variant: Variant): boolean`
 
@@ -76,7 +93,7 @@ Determine whether a given `tag` is of `Type`.
 > `safeUnion(types: Array<String>[, options: { prefix: String }]): { methods, variants }`
 
 For library authors accepting arbitrary strings for type names, `safeUnion` is `union` but returns distinct collections of methods and type variants.
-This will not throw if a type is "match" or "matches".
+This will not throw if a type is "match", "matcher", or "matches".
 
 ## Name
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,6 @@ function checkTypes (types) {
   for (let i = 0; i < types.length; i++) {
     const type = types[i]
     invariant(typeof type === 'string', 'Tag type must be a string')
-    invariant(type !== 'match', 'Tag type cannot be "match"')
-    invariant(type !== 'matches', 'Tag type cannot be "matches"')
     invariant(!seen[type], `Duplicate tag type "${type}". Types must be unique`)
     seen[type] = true
   }
@@ -63,7 +61,7 @@ function checkType (type, tagUnion) {
   invariant(false, `Type must be a type of the union`)
 }
 
-function union (types, options) {
+function safeUnion (types, options) {
   if (process.env.NODE_ENV !== 'production') {
     checkTypes(types)
   }
@@ -78,7 +76,7 @@ function union (types, options) {
         tag.type.slice(prefixSize)
     : x => x && x.type
 
-  const tagUnion = {
+  const methods = {
     match (tag, handlers, catchAll) {
       const tagType = stripPrefix(tag)
       if (process.env.NODE_ENV !== 'production') {
@@ -93,20 +91,33 @@ function union (types, options) {
       const tagType = stripPrefix(tag)
       if (process.env.NODE_ENV !== 'production') {
         checkTag(tag, tagType, types)
-        checkType(type, tagUnion)
+        checkType(type, variants)
       }
 
-      return !!(tagType && tagUnion[tagType] === type)
+      return !!(tagType && variants[tagType] === type)
     }
   }
 
+  const variants = {}
   for (let i = 0; i < types.length; i++) {
     const type = types[i]
     const prefixedType = prefix + type
-    tagUnion[type] = data => ({ type: prefixedType, data })
+    variants[type] = data => ({ type: prefixedType, data })
   }
 
-  return tagUnion
+  return { variants, methods }
+}
+
+function union (types, options) {
+  const { variants, methods } = safeUnion(types, options)
+  for (const key in variants) {
+    if (process.env.NODE_ENV !== 'production') {
+      invariant(!methods[key], `Tag type cannot be "${key}"`)
+    }
+    methods[key] = variants[key]
+  }
+  return methods
 }
 
 exports.union = union
+exports.safeUnion = safeUnion

--- a/src/index.js
+++ b/src/index.js
@@ -76,17 +76,27 @@ function safeUnion (types, options) {
         tag.type.slice(prefixSize)
     : x => x && x.type
 
-  const methods = {
-    match (tag, handlers, catchAll) {
+  const matcher = (handlers, catchAll) => {
+    if (process.env.NODE_ENV !== 'production') {
+      checkMatch(handlers, catchAll, types)
+    }
+
+    return function _matcher (tag, context) {
       const tagType = stripPrefix(tag)
       if (process.env.NODE_ENV !== 'production') {
         checkTag(tag, tagType, types)
-        checkMatch(handlers, catchAll, types)
       }
 
       const match = tagType && handlers[tagType]
-      return match ? match(tag.data) : catchAll()
+      return match ? match(tag.data, context) : catchAll(context)
+    }
+  }
+
+  const methods = {
+    match (tag, handlers, catchAll) {
+      return matcher(handlers, catchAll)(tag)
     },
+    matcher,
     matches (tag, type) {
       const tagType = stripPrefix(tag)
       if (process.env.NODE_ENV !== 'production') {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { union } from '../src/'
+import { union, safeUnion } from '../src/'
 
 test('union() should return an object with match method', t => {
   const Msg = union([])
@@ -199,4 +199,20 @@ test('tags should be de/serialize-able with prefixes', t => {
   )
 
   t.true(Msg.matches(tagCopy, Msg.Foo))
+})
+
+test('safeUnion() allows "match" and "matches" types', t => {
+  const { variants, methods } = safeUnion(['Foo', 'match', 'matches'])
+
+  t.true(methods.matches(variants.match(), variants.match))
+  t.true(methods.matches(variants.matches(), variants.matches))
+
+  t.is(
+    methods.match(variants.Foo(), {
+      Foo: () => 1,
+      match: () => 2,
+      matches: () => 3
+    }),
+    1
+  )
 })

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,10 @@ test('union() should throw if there is a kind "match"', t => {
   t.throws(() => union(['match']), /cannot be "match"/)
 })
 
+test('union() should throw if there is a kind "matcher"', t => {
+  t.throws(() => union(['matcher']), /cannot be "matcher"/)
+})
+
 test('union() should throw if there is a kind "matches"', t => {
   t.throws(() => union(['matches']), /cannot be "matches"/)
 })
@@ -122,6 +126,21 @@ test('match() should throw if a catch-all is not needed', t => {
   }, /remove unnecessary catch-all/)
 })
 
+test('matcher() should work', t => {
+  const Msg = union(['Inc', 'Dec', 'Wut'])
+  const update = Msg.matcher(
+    {
+      Inc: (num, memo) => memo + num,
+      Dec: (num, memo) => memo - num
+    },
+    memo => memo * memo
+  )
+
+  t.is(update(Msg.Inc(5), 1), 6)
+  t.is(update(Msg.Dec(2), 5), 3)
+  t.is(update(Msg.Wut(0), 2), 4)
+})
+
 test('matches() should return whether the tag matches type', t => {
   const Msg = union(['Foo', 'Bar'])
   t.true(Msg.matches(Msg.Foo(), Msg.Foo))
@@ -201,17 +220,24 @@ test('tags should be de/serialize-able with prefixes', t => {
   t.true(Msg.matches(tagCopy, Msg.Foo))
 })
 
-test('safeUnion() allows "match" and "matches" types', t => {
-  const { variants, methods } = safeUnion(['Foo', 'match', 'matches'])
+test('safeUnion() allows "match", "matcher", and "matches" types', t => {
+  const { variants, methods } = safeUnion([
+    'Foo',
+    'match',
+    'matcher',
+    'matches'
+  ])
 
   t.true(methods.matches(variants.match(), variants.match))
+  t.true(methods.matches(variants.matcher(), variants.matcher))
   t.true(methods.matches(variants.matches(), variants.matches))
 
   t.is(
     methods.match(variants.Foo(), {
       Foo: () => 1,
       match: () => 2,
-      matches: () => 3
+      matcher: () => 3,
+      matches: () => 4
     }),
     1
   )


### PR DESCRIPTION
Closes #17 

This adds two new things:

`safeUnion` addresses issue #17 as a special `union` for library authors. They can use Tagmeme without having the reserved `match*` method exceptions leak into their consumers. I decided:

1. A different syntax for `union` would be less good for 99.9% of code (applications).
2. I have no interest in breaking the current API and going back and rewriting all my apps.
3. Having this separate API means we can grow to have more helper methods in the future with minimal breakage since we can know which places would be effected and which never can be.

`Union.matcher` is something I have floated on for a long time. In Raj, I always write:

```js
function update (msg, model) {
  return Msg.match(msg, { /* ... */ })
}
```

Which is boilerplate I don't care to write. Also creating and validating static handlers on every call to update isn't the best for performance. With `Union.matcher`, the above becomes:

```js
const update = Msg.matcher({ /* ... */ })
```

This is much better. Hopefully the use cases for this are apparent beyond Raj. I've certainly seen others but that is definitely the most immediate use case for me.