### PR TITLE
Harden against Object.prototype

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 const invariant = require('invariant')
+const hasOwnProperty = Object.prototype.hasOwnProperty
 
 function checkTypes (types) {
   invariant(Array.isArray(types), 'types must be an array')
 
-  const seen = {}
+  const seen = Object.create(null)
   for (let i = 0; i < types.length; i++) {
     const type = types[i]
     invariant(typeof type === 'string', 'Tag type must be a string')
@@ -14,7 +15,7 @@ function checkTypes (types) {
 
 function checkMatch (handlers, catchAll, types) {
   const seenTypes = []
-  for (let key in handlers) {
+  for (const key in handlers) {
     invariant(
       types.includes(key),
       `Key "${key}" is not a tag type of the union`
@@ -87,7 +88,7 @@ function safeUnion (types, options) {
         checkTag(tag, tagType, types)
       }
 
-      const match = tagType && handlers[tagType]
+      const match = hasOwnProperty.call(handlers, tagType) && handlers[tagType]
       return match ? match(tag.data, context) : catchAll(context)
     }
   }
@@ -108,7 +109,7 @@ function safeUnion (types, options) {
     }
   }
 
-  const variants = {}
+  const variants = Object.create(null)
   for (let i = 0; i < types.length; i++) {
     const type = types[i]
     const prefixedType = prefix + type
@@ -120,13 +121,16 @@ function safeUnion (types, options) {
 
 function union (types, options) {
   const { variants, methods } = safeUnion(types, options)
-  for (const key in variants) {
+  for (const key in methods) {
     if (process.env.NODE_ENV !== 'production') {
-      invariant(!methods[key], `Tag type cannot be "${key}"`)
+      invariant(
+        !hasOwnProperty.call(variants, key),
+        `Tag type cannot be "${key}"`
+      )
     }
-    methods[key] = variants[key]
+    variants[key] = methods[key]
   }
-  return methods
+  return variants
 }
 
 exports.union = union

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function checkMatch (handlers, catchAll, types) {
 function checkTag (tag, tagType, types) {
   invariant(typeof tag === 'object', 'Tag must be an object')
   invariant(typeof tag.type === 'string', 'Tag type must be a string')
-  invariant(tagType, 'Tag type must be prefixed')
+  invariant(typeof tagType === 'string', 'Tag type must be prefixed')
   invariant(types.includes(tagType), `Tag must be a tag of the union`)
 }
 
@@ -105,7 +105,7 @@ function safeUnion (types, options) {
         checkType(type, variants)
       }
 
-      return !!(tagType && variants[tagType] === type)
+      return !!(typeof tagType === 'string' && variants[tagType] === type)
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -148,6 +148,16 @@ test('match() should not treat Object.prototype properties as handlers', t => {
   A.match(A.constructor(1), {}, () => t.pass())
 })
 
+test('match() should work for empty string', t => {
+  const A = union([''])
+  A.match(A[''](1), { '': () => t.pass() })
+})
+
+test('match() should work for empty string with prefix', t => {
+  const A = union([''], { prefix: 'abc' })
+  A.match(A[''](1), { '': () => t.pass() })
+})
+
 test('matcher() should work', t => {
   const Msg = union(['Inc', 'Dec', 'Wut'])
   const update = Msg.matcher(
@@ -212,6 +222,11 @@ test('matches() should throw if type is not of the union', t => {
   t.throws(() => {
     A.matches(A.Foo(), B.Bar)
   }, /must be a type of the union/)
+})
+
+test('matches() should work for empty string', t => {
+  const A = union([''])
+  t.true(A.matches(A[''](1), A['']))
 })
 
 test('tags should be de/serialize-able', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,21 @@ test('union() prefix should prevent name conflicts', t => {
   t.notDeepEqual(A.Foo(), B.Foo())
 })
 
+test('union() should not throw for Object.prototype type names', t => {
+  const types = Object.getOwnPropertyNames(Object.prototype)
+  t.notThrows(() => {
+    union(types)
+  })
+})
+
+test('union() should not have Object.prototype properties (unless specified)', t => {
+  const props = Object.getOwnPropertyNames(Object.prototype)
+  const A = union([])
+  props.forEach(prop => {
+    t.is(A[prop], undefined, `Property ${prop} should be undefined`)
+  })
+})
+
 test('match() should return the handler return value', t => {
   const Msg = union(['Foo'])
   const val = Msg.Foo()
@@ -124,6 +139,13 @@ test('match() should throw if a catch-all is not needed', t => {
   t.throws(() => {
     Msg.match(val, { Foo: () => {} }, () => {})
   }, /remove unnecessary catch-all/)
+})
+
+test('match() should not treat Object.prototype properties as handlers', t => {
+  const types = Object.getOwnPropertyNames(Object.prototype)
+  const A = union(types)
+
+  A.match(A.constructor(1), {}, () => t.pass())
 })
 
 test('matcher() should work', t => {


### PR DESCRIPTION
Since we'll be accepting arbitrary strings with `safeUnion`, we should be hardened against someone doing `safeUnion(['constructor'])` and the like.